### PR TITLE
docs(core-wg): rename AGP to SLIM and add sub-project repo links

### DIFF
--- a/working-groups/core/CHARTER.md
+++ b/working-groups/core/CHARTER.md
@@ -7,14 +7,14 @@ The mission of the AGNTCY Core Working Group is to contribute and to maintain th
 ## Goals
 
 The primary goal of the Core Working Group is to develop and maintain all core components of AGNTCY, including:
-- Agent Gateway Protocol (AGP)
-- Agent Directory
-- Continuous System Integration Testing (CSIT)
-- Open Agentic Schema Framework (OASF)
-- Agent Connect Protocol (ACP)
-- Workflow server
-- IO Mapper
-- API bridge
+- [Secure Low-Latency Interactive Messaging (SLIM)](https://github.com/agntcy/slim)
+- [Agent Directory](https://github.com/agntcy/dir)
+- [Continuous System Integration Testing (CSIT)](https://github.com/agntcy/csit)
+- [Open Agentic Schema Framework (OASF)](https://github.com/agntcy/oasf)
+- [Agent Connect Protocol (ACP)](https://github.com/agntcy/acp-spec)
+- [Workflow server](https://github.com/agntcy/workflow-srv)
+- [IO Mapper](https://github.com/agntcy/iomapper-agnt)
+- [API bridge](https://github.com/agntcy/api-bridge-agnt)
 
 ## Scope
 


### PR DESCRIPTION
Fixes #30

The Core WG charter still referenced "Agent Gateway Protocol (AGP)", which was renamed to Secure Low-Latency Interactive Messaging (SLIM). This updates the entry to use the current name and links to https://github.com/agntcy/slim.

Per the recommendation in the issue, this also adds GitHub repository links for all other core components listed in the charter.

Please let me know as ACP, Workflow server, IO Mapper, and API bridge are currently archived repositories 
happy to remove/update/delete those entries if the project has moved on from them.